### PR TITLE
fix full subscription flow +cleanup code

### DIFF
--- a/ckanext/mailchimp/controller.py
+++ b/ckanext/mailchimp/controller.py
@@ -1,60 +1,25 @@
 # coding=utf-8
 import ckan.plugins.toolkit as tk
 from ckan.common import request
-from ckan.lib.helpers import flash_success, flash_error, lang
+from ckan.lib.helpers import flash_success, flash_error
 
 from ckanext.mailchimp.logic.action.create import mailchimp_add_subscriber
 from ckanext.mailchimp.util import name_from_email
 
-flash_messages = {
-    "SUCCESS": {
-        "en": "A confirmation email was sent to you to verify your email address. Please check your spam folder if "
-              "you did not receive this email. If the problem persists, contact us at <a "
-              "href='mailto:contact@transportdata.be'>contact@transportdata.be</a>",
-        "nl": "Een bevestigingsmail werd verstuurd naar uw email adres. Controleer uw spam folder indien u deze niet "
-              "ontvangen heeft. Bij verdere problemen kan u ons contacteren via <a "
-              "href='mailto:contact@transportdata.be'>contact@transportdata.be</a> ",
-        "fr": "Nous vous avons envoyé un mail de confirmation. Si vous ne le voyez pas, vérifiez dans vos spam s’il "
-              "ne s’y trouve pas. Si le problème persiste, prenez contact avec nous via <a "
-              "href='mailto:contact@transportdata.be'>contact@transportdata.be</a> ",
-        "de": "Eine E-Mail wurde an Sie gesendet, um Ihre E-Mail-Adresse zu bestätigen. Bitte überprüfen Sie auch "
-              "Ihren Spam-Ordner wenn Sie diese E-Mail nicht erhalten haben. Wenn das Problem weiterhin besteht, "
-              "kontaktiere uns per <a href='mailto:contact@transportdata.be'>contact@transportdata.be</a>  "
-    },
-    "ERROR_ADD": {
-        "en": "An error occurred while adding you to the mailing list.",
-        "nl": "Er is een fout opgetreden bij het toevoegen aan de mailinglijst.",
-        "fr": "Une erreur s'est produite lors de votre ajout à la liste de diffusion.",
-        "de": "Beim Hinzufügen zur Mailingliste ist ein Fehler aufgetreten."
-    },
-    "ALREADY_SUBSCRIBED": {
-        "en": "You already subscribed to the newsletter.",
-        "nl": "U bent reeds ingeschreven op de mailinglijst.",
-        "fr": "Vous êtes déjà abonné à la newsletter.",
-        "de": "Sie haben den Newsletter bereits abonniert."
-    },
-    "ERROR_UPDATE": {
-        "en": "An error occurred while updating your information.",
-        "nl": "Er is een fout opgetreden tijdens het updaten van uw informatie",
-        "fr": "Une erreur s'est produite lors de la mise à jour de vos informations.",
-        "de": "Beim Aktualisieren Ihrer Informationen ist ein Fehler aufgetreten."
-    },
-    "ERROR_NOT_VALID": {
-        "en": "Please provide a valid email address!",
-        "nl": "Gelieve een geldig email adres op te geven!",
-        "fr": "Veuillez fournir une adresse email valide!",
-        "de": "Bitte geben Sie eine gültige E-Mail Adresse an!"
-    }
+FLASH_MESSAGES = {
+    "SUCCESS": tk._("A confirmation email was sent to you to verify your email address. Please check your spam folder if you did not receive this email. If the problem persists, contact us at <a href='mailto:contact@transportdata.be'>contact@transportdata.be</a>"),
+    "ERROR_ADD": tk._("An error occurred while adding you to the mailing list."),
+    "ALREADY_SUBSCRIBED": tk._("You already subscribed to the newsletter."),
+    "ERROR_UPDATE": tk._("An error occurred while updating your information."),
+    "ERROR_NOT_VALID": tk._("Please provide a valid email address!"),
 }
 
 
-def translate_flash_message(msg_key, lang):
-    msg = flash_messages.get(msg_key, {})
-    if lang in msg:
-        msg_translated = msg.get(lang, "An error occurred")
-    else:
-        msg_translated = msg.get("en", "An error occurred")
-    return msg_translated
+def flash_message(msg_key):
+    message = FLASH_MESSAGES.get(msg_key)
+    if not message:
+        return tk._("An error occurred")
+    return message
 
 def subscribe():
     email = request.form.get('email') or request.args.get('email')
@@ -68,10 +33,10 @@ def subscribe():
         first, last = name_from_email(email)
         success, msg_key = mailchimp_add_subscriber(first, last, email, tags=["Mailinglist-user"])
         if success:
-            flash_success(translate_flash_message(msg_key, lang()), allow_html=True)
+            flash_success(flash_message(msg_key), allow_html=True)
         else:
-            flash_error(translate_flash_message(msg_key, lang()), allow_html=True)
+            flash_error(flash_message(msg_key), allow_html=True)
     else:
-        flash_error(translate_flash_message("ERROR_NOT_VALID", lang()), allow_html=True)
+        flash_error(flash_message("ERROR_NOT_VALID"), allow_html=True)
 
     return tk.redirect_to(tk.url_for("home.index"))

--- a/ckanext/mailchimp/helpers/__init__.py
+++ b/ckanext/mailchimp/helpers/__init__.py
@@ -1,0 +1,10 @@
+
+from ckanext.mailchimp.logic.mailchimp import mailchimp_client
+
+def mailchimp_is_user_subscribed(user_email):
+  client = mailchimp_client()
+  return client.is_active_subscriber(user_email)
+
+def mailchimp_is_user_pending(user_email):
+  client = mailchimp_client()
+  return client.is_pending_subscriber(user_email)

--- a/ckanext/mailchimp/i18n/ckanext-mailchimp.pot
+++ b/ckanext/mailchimp/i18n/ckanext-mailchimp.pot
@@ -1,22 +1,50 @@
 # Translations template for ckanext-mailchimp.
-# Copyright (C) 2019 ORGANIZATION
+# Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the ckanext-mailchimp
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: ckanext-mailchimp 0.0.1\n"
+"Project-Id-Version: ckanext-mailchimp 1.1.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-10-18 15:21+0200\n"
+"POT-Creation-Date: 2025-10-16 08:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.15.0\n"
+
+#: ckanext/mailchimp/controller.py:10
+msgid ""
+"A confirmation email was sent to you to verify your email address. Please "
+"check your spam folder if you did not receive this email. If the problem "
+"persists, contact us at <a "
+"href='mailto:contact@transportdata.be'>contact@transportdata.be</a>"
+msgstr ""
+
+#: ckanext/mailchimp/controller.py:11
+msgid "An error occurred while adding you to the mailing list."
+msgstr ""
+
+#: ckanext/mailchimp/controller.py:12
+msgid "You already subscribed to the newsletter."
+msgstr ""
+
+#: ckanext/mailchimp/controller.py:13
+msgid "An error occurred while updating your information."
+msgstr ""
+
+#: ckanext/mailchimp/controller.py:14
+msgid "Please provide a valid email address!"
+msgstr ""
+
+#: ckanext/mailchimp/controller.py:21
+msgid "An error occurred"
+msgstr ""
 
 #: ckanext/mailchimp/templates/home/snippets/contact.html:3
 msgid "Subscribe to the mailing list"
@@ -43,117 +71,12 @@ msgstr ""
 msgid "Enter your email address"
 msgstr ""
 
-#: ckanext/mailchimp/templates/user/edit_user_form.html:7
-msgid "Change details"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:8
-#: ckanext/mailchimp/templates/user/new_user_form.html:5
-msgid "Username"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:10
-msgid "Full name"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:10
-msgid "eg. Joe Bloggs"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:12
-#: ckanext/mailchimp/templates/user/new_user_form.html:7
-msgid "Email"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:12
-msgid "eg. joe@example.com"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:14
-msgid "About"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:14
-msgid "A little information about yourself"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:17
-msgid "Subscribe to notification emails"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:18
-msgid ""
-"You will receive notification emails from {site_title}, e.g. when you have "
-"new activities on your dashboard."
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:22
-#: ckanext/mailchimp/templates/user/new_user_form.html:10
+#: ckanext/mailchimp/templates/user/edit_user_form.html:9
+#: ckanext/mailchimp/templates/user/new_user_form.html:6
 msgid "Subscribe to newsletter"
 msgstr ""
 
-#: ckanext/mailchimp/templates/user/edit_user_form.html:28
-msgid "Change password"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:31
-msgid "Sysadmin Password"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:31
-msgid "Old Password"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:39
-#: ckanext/mailchimp/templates/user/new_user_form.html:8
-msgid "Password"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:41
-msgid "Confirm Password"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:47
-msgid "Are you sure you want to delete this User?"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:47
-msgid "Delete"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:52
-msgid "Are you sure you want to regenerate the API key?"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:52
-msgid "Regenerate API Key"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:56
-msgid "Update Profile"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:5
-msgid "username"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:6
-msgid "Full Name"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:6
-msgid "Joe Bloggs"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:7
-msgid "joe@example.com"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:9
-msgid "Confirm"
-msgstr ""
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:20
-msgid "Create Account"
+#: ckanext/mailchimp/templates/user/edit_user_form.html:13
+msgid "An email has been sent to you to confirm your subscription."
 msgstr ""
 

--- a/ckanext/mailchimp/i18n/de/LC_MESSAGES/ckanext-mailchimp.po
+++ b/ckanext/mailchimp/i18n/de/LC_MESSAGES/ckanext-mailchimp.po
@@ -8,16 +8,44 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-mailchimp 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-10-18 15:21+0200\n"
+"POT-Creation-Date: 2025-10-16 08:39+0000\n"
 "PO-Revision-Date: 2019-09-20 14:10+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
 "Language-Team: de <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.15.0\n"
+
+#: ckanext/mailchimp/controller.py:10
+msgid ""
+"A confirmation email was sent to you to verify your email address. Please"
+" check your spam folder if you did not receive this email. If the problem"
+" persists, contact us at <a "
+"href='mailto:contact@transportdata.be'>contact@transportdata.be</a>"
+msgstr "Eine E-Mail wurde an Sie gesendet, um Ihre E-Mail-Adresse zu bestätigen. Bitte überprüfen Sie auch Ihren Spam-Ordner wenn Sie diese E-Mail nicht erhalten haben. Wenn das Problem weiterhin besteht, kontaktiere uns per <a href='mailto:contact@transportdata.be'>contact@transportdata.be</a>"
+
+#: ckanext/mailchimp/controller.py:11
+msgid "An error occurred while adding you to the mailing list."
+msgstr "Beim Hinzufügen zur Mailingliste ist ein Fehler aufgetreten."
+
+#: ckanext/mailchimp/controller.py:12
+msgid "You already subscribed to the newsletter."
+msgstr "Sie haben den Newsletter bereits abonniert."
+
+#: ckanext/mailchimp/controller.py:13
+msgid "An error occurred while updating your information."
+msgstr "Beim Aktualisieren Ihrer Informationen ist ein Fehler aufgetreten."
+
+#: ckanext/mailchimp/controller.py:14
+msgid "Please provide a valid email address!"
+msgstr "Bitte geben Sie eine gültige E-Mail Adresse an!"
+
+#: ckanext/mailchimp/controller.py:21
+msgid "An error occurred"
+msgstr ""
 
 #: ckanext/mailchimp/templates/home/snippets/contact.html:3
 msgid "Subscribe to the mailing list"
@@ -36,9 +64,9 @@ msgstr "Abonnieren Sie"
 msgid "SUBSCRIBE"
 msgstr "ABONNIEREN SIE"
 
+# | msgid "Subscribe to newsletter"
 #: ckanext/mailchimp/templates/home/snippets/newsletter.html:6
 #, fuzzy
-#| msgid "Subscribe to newsletter"
 msgid "TO NEWSLETTER"
 msgstr "Abonnieren Sie den Newsletter"
 
@@ -46,120 +74,12 @@ msgstr "Abonnieren Sie den Newsletter"
 msgid "Enter your email address"
 msgstr "Geben Ihre E-Mail an"
 
-#: ckanext/mailchimp/templates/user/edit_user_form.html:7
-msgid "Change details"
-msgstr "Kontakdaten ändern"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:8
-#: ckanext/mailchimp/templates/user/new_user_form.html:5
-msgid "Username"
-msgstr "Benutzername"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:10
-msgid "Full name"
-msgstr "Vollständiger Name"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:10
-msgid "eg. Joe Bloggs"
-msgstr "zum B. Joe Bloggs"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:12
-#: ckanext/mailchimp/templates/user/new_user_form.html:7
-msgid "Email"
-msgstr "E-Mail"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:12
-msgid "eg. joe@example.com"
-msgstr "zum B. joe@Beispiel.com"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:14
-msgid "About"
-msgstr "Über"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:14
-msgid "A little information about yourself"
-msgstr "Angaben über Sie"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:17
-msgid "Subscribe to notification emails"
-msgstr "Abonnieren Sie die E-Mail-Meldungen"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:18
-msgid ""
-"You will receive notification emails from {site_title}, e.g. when you "
-"have new activities on your dashboard."
-msgstr "Sie werden E-Mail-Meldungen von {site_title} empfangen, zum B. wenn Sie neue Aktivitäten in Ihrem Dashboard haben."
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:22
-#: ckanext/mailchimp/templates/user/new_user_form.html:10
+#: ckanext/mailchimp/templates/user/edit_user_form.html:9
+#: ckanext/mailchimp/templates/user/new_user_form.html:6
 msgid "Subscribe to newsletter"
 msgstr "Abonnieren Sie den Newsletter"
 
-#: ckanext/mailchimp/templates/user/edit_user_form.html:28
-msgid "Change password"
-msgstr "Passwort ändern"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:31
-msgid "Sysadmin Password"
-msgstr "Passwort Systemadministrator"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:31
-msgid "Old Password"
-msgstr "Ehemaliges Passwort"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:39
-#: ckanext/mailchimp/templates/user/new_user_form.html:8
-msgid "Password"
-msgstr "Passwort"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:41
-msgid "Confirm Password"
-msgstr "Passwort bestätigen"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:47
-msgid "Are you sure you want to delete this User?"
-msgstr "Sind Sie sicher, dass Sie diesen Benutzer löschen wollen?"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:47
-msgid "Delete"
-msgstr "Löschen"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:52
-msgid "Are you sure you want to regenerate the API key?"
-msgstr "Sind Sie sicher, dass Sie den API-Schlüssel neu kompilieren wollen?"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:52
-msgid "Regenerate API Key"
-msgstr "API-Schlüssel neu kompilieren"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:56
-msgid "Update Profile"
-msgstr "Profil updaten"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:5
-msgid "username"
-msgstr "Benutzername"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:6
-msgid "Full Name"
-msgstr "Vollständiger Name"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:6
-msgid "Joe Bloggs"
-msgstr "Joe Bloggs"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:7
-msgid "joe@example.com"
-msgstr "joe@Beispiel.com"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:9
-msgid "Confirm"
-msgstr "Bestätigen"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:20
-msgid "Create Account"
-msgstr "Account anlegen"
-
-#~ msgid "SUBSCRIBE TO NEWSLETTER"
-#~ msgstr "ABONNIEREN SIE DEN NEWSLETTER"
+#: ckanext/mailchimp/templates/user/edit_user_form.html:13
+msgid "An email has been sent to you to confirm your subscription."
+msgstr ""
 

--- a/ckanext/mailchimp/i18n/en/LC_MESSAGES/ckanext-mailchimp.po
+++ b/ckanext/mailchimp/i18n/en/LC_MESSAGES/ckanext-mailchimp.po
@@ -8,16 +8,44 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-mailchimp 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-10-18 15:21+0200\n"
+"POT-Creation-Date: 2025-10-16 08:39+0000\n"
 "PO-Revision-Date: 2019-09-20 14:10+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
 "Language-Team: en <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.15.0\n"
+
+#: ckanext/mailchimp/controller.py:10
+msgid ""
+"A confirmation email was sent to you to verify your email address. Please"
+" check your spam folder if you did not receive this email. If the problem"
+" persists, contact us at <a "
+"href='mailto:contact@transportdata.be'>contact@transportdata.be</a>"
+msgstr ""
+
+#: ckanext/mailchimp/controller.py:11
+msgid "An error occurred while adding you to the mailing list."
+msgstr ""
+
+#: ckanext/mailchimp/controller.py:12
+msgid "You already subscribed to the newsletter."
+msgstr ""
+
+#: ckanext/mailchimp/controller.py:13
+msgid "An error occurred while updating your information."
+msgstr ""
+
+#: ckanext/mailchimp/controller.py:14
+msgid "Please provide a valid email address!"
+msgstr ""
+
+#: ckanext/mailchimp/controller.py:21
+msgid "An error occurred"
+msgstr ""
 
 #: ckanext/mailchimp/templates/home/snippets/contact.html:3
 msgid "Subscribe to the mailing list"
@@ -36,9 +64,9 @@ msgstr "Subscribe"
 msgid "SUBSCRIBE"
 msgstr "SUBSCRIBE"
 
+# | msgid "Subscribe to newsletter"
 #: ckanext/mailchimp/templates/home/snippets/newsletter.html:6
 #, fuzzy
-#| msgid "Subscribe to newsletter"
 msgid "TO NEWSLETTER"
 msgstr "Subscribe to newsletter"
 
@@ -46,120 +74,12 @@ msgstr "Subscribe to newsletter"
 msgid "Enter your email address"
 msgstr "Enter your email address"
 
-#: ckanext/mailchimp/templates/user/edit_user_form.html:7
-msgid "Change details"
-msgstr "Change details"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:8
-#: ckanext/mailchimp/templates/user/new_user_form.html:5
-msgid "Username"
-msgstr "Username"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:10
-msgid "Full name"
-msgstr "Full name"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:10
-msgid "eg. Joe Bloggs"
-msgstr "eg. Joe Bloggs"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:12
-#: ckanext/mailchimp/templates/user/new_user_form.html:7
-msgid "Email"
-msgstr "Email"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:12
-msgid "eg. joe@example.com"
-msgstr "eg. joe@example.com"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:14
-msgid "About"
-msgstr "About"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:14
-msgid "A little information about yourself"
-msgstr "A little information about yourself"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:17
-msgid "Subscribe to notification emails"
-msgstr "Subscribe to notification emails"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:18
-msgid ""
-"You will receive notification emails from {site_title}, e.g. when you "
-"have new activities on your dashboard."
-msgstr "You will receive notification emails from {site_title}, e.g. when you have new activities on your dashboard."
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:22
-#: ckanext/mailchimp/templates/user/new_user_form.html:10
+#: ckanext/mailchimp/templates/user/edit_user_form.html:9
+#: ckanext/mailchimp/templates/user/new_user_form.html:6
 msgid "Subscribe to newsletter"
 msgstr "Subscribe to newsletter"
 
-#: ckanext/mailchimp/templates/user/edit_user_form.html:28
-msgid "Change password"
-msgstr "Change password"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:31
-msgid "Sysadmin Password"
-msgstr "Sysadmin Password"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:31
-msgid "Old Password"
-msgstr "Old Password"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:39
-#: ckanext/mailchimp/templates/user/new_user_form.html:8
-msgid "Password"
-msgstr "Password"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:41
-msgid "Confirm Password"
-msgstr "Confirm Password"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:47
-msgid "Are you sure you want to delete this User?"
-msgstr "Are you sure you want to delete this User?"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:47
-msgid "Delete"
-msgstr "Delete"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:52
-msgid "Are you sure you want to regenerate the API key?"
-msgstr "Are you sure you want to regenerate the API key?"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:52
-msgid "Regenerate API Key"
-msgstr "Regenerate API Key"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:56
-msgid "Update Profile"
-msgstr "Update Profile"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:5
-msgid "username"
-msgstr "username"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:6
-msgid "Full Name"
-msgstr "Full Name"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:6
-msgid "Joe Bloggs"
-msgstr "Joe Bloggs"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:7
-msgid "joe@example.com"
-msgstr "joe@example.com"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:9
-msgid "Confirm"
-msgstr "Confirm"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:20
-msgid "Create Account"
-msgstr "Create Account"
-
-#~ msgid "SUBSCRIBE TO NEWSLETTER"
-#~ msgstr "SUBSCRIBE TO NEWSLETTER"
+#: ckanext/mailchimp/templates/user/edit_user_form.html:13
+msgid "An email has been sent to you to confirm your subscription."
+msgstr ""
 

--- a/ckanext/mailchimp/i18n/fr/LC_MESSAGES/ckanext-mailchimp.po
+++ b/ckanext/mailchimp/i18n/fr/LC_MESSAGES/ckanext-mailchimp.po
@@ -8,16 +8,44 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-mailchimp 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-10-18 15:21+0200\n"
+"POT-Creation-Date: 2025-10-16 08:39+0000\n"
 "PO-Revision-Date: 2019-09-20 14:10+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
 "Language-Team: fr <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.15.0\n"
+
+#: ckanext/mailchimp/controller.py:10
+msgid ""
+"A confirmation email was sent to you to verify your email address. Please"
+" check your spam folder if you did not receive this email. If the problem"
+" persists, contact us at <a "
+"href='mailto:contact@transportdata.be'>contact@transportdata.be</a>"
+msgstr "Nous vous avons envoyé un mail de confirmation. Si vous ne le voyez pas, vérifiez dans vos spam s’il ne s’y trouve pas. Si le problème persiste, prenez contact avec nous via <a href='mailto:contact@transportdata.be'>contact@transportdata.be</a>"
+
+#: ckanext/mailchimp/controller.py:11
+msgid "An error occurred while adding you to the mailing list."
+msgstr "Une erreur s'est produite lors de votre ajout à la liste de diffusion."
+
+#: ckanext/mailchimp/controller.py:12
+msgid "You already subscribed to the newsletter."
+msgstr "Vous êtes déjà abonné à la newsletter."
+
+#: ckanext/mailchimp/controller.py:13
+msgid "An error occurred while updating your information."
+msgstr "Une erreur s'est produite lors de la mise à jour de vos informations."
+
+#: ckanext/mailchimp/controller.py:14
+msgid "Please provide a valid email address!"
+msgstr "Veuillez fournir une adresse email valide!"
+
+#: ckanext/mailchimp/controller.py:21
+msgid "An error occurred"
+msgstr ""
 
 #: ckanext/mailchimp/templates/home/snippets/contact.html:3
 msgid "Subscribe to the mailing list"
@@ -36,9 +64,9 @@ msgstr "Inscrivez-vous"
 msgid "SUBSCRIBE"
 msgstr "INSCRIVEZ-VOUS"
 
+# | msgid "Subscribe to newsletter"
 #: ckanext/mailchimp/templates/home/snippets/newsletter.html:6
 #, fuzzy
-#| msgid "Subscribe to newsletter"
 msgid "TO NEWSLETTER"
 msgstr "Inscrivez-vous à la lettre de diffusion"
 
@@ -46,120 +74,12 @@ msgstr "Inscrivez-vous à la lettre de diffusion"
 msgid "Enter your email address"
 msgstr "Indiquez votre adresse e-mail"
 
-#: ckanext/mailchimp/templates/user/edit_user_form.html:7
-msgid "Change details"
-msgstr "Changer les coordonnées"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:8
-#: ckanext/mailchimp/templates/user/new_user_form.html:5
-msgid "Username"
-msgstr "Nom d'utilisateur"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:10
-msgid "Full name"
-msgstr "Nom complet"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:10
-msgid "eg. Joe Bloggs"
-msgstr "ex. Joe Bloggs"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:12
-#: ckanext/mailchimp/templates/user/new_user_form.html:7
-msgid "Email"
-msgstr "e-mail"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:12
-msgid "eg. joe@example.com"
-msgstr "ex. joe@exemple.com"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:14
-msgid "About"
-msgstr "A propos"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:14
-msgid "A little information about yourself"
-msgstr "Quelques informations sur vous"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:17
-msgid "Subscribe to notification emails"
-msgstr "Inscrivez-vous aux e-mails de notification"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:18
-msgid ""
-"You will receive notification emails from {site_title}, e.g. when you "
-"have new activities on your dashboard."
-msgstr "Vous recevrez des e-mails de notification de {site_title}, par ex. lorsque vous avez de nouvelles activités sur votre tableau de bord."
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:22
-#: ckanext/mailchimp/templates/user/new_user_form.html:10
+#: ckanext/mailchimp/templates/user/edit_user_form.html:9
+#: ckanext/mailchimp/templates/user/new_user_form.html:6
 msgid "Subscribe to newsletter"
 msgstr "Inscrivez-vous à la lettre de diffusion"
 
-#: ckanext/mailchimp/templates/user/edit_user_form.html:28
-msgid "Change password"
-msgstr "Changer le mot de passe"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:31
-msgid "Sysadmin Password"
-msgstr "Mot de passe administrateur système"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:31
-msgid "Old Password"
-msgstr "Ancien mot de passe"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:39
-#: ckanext/mailchimp/templates/user/new_user_form.html:8
-msgid "Password"
-msgstr "Mot de passe"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:41
-msgid "Confirm Password"
-msgstr "Confirmer mot de passe"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:47
-msgid "Are you sure you want to delete this User?"
-msgstr "Êtes-vous sûr de vouloir supprimer cet Utilisateur?"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:47
-msgid "Delete"
-msgstr "Supprimer"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:52
-msgid "Are you sure you want to regenerate the API key?"
-msgstr "Êtes-vous sûr de vouloir recompiler la clé API?"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:52
-msgid "Regenerate API Key"
-msgstr "Recompiler clé API"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:56
-msgid "Update Profile"
-msgstr "Mise à jour du profil"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:5
-msgid "username"
-msgstr "nom d'utilisateur"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:6
-msgid "Full Name"
-msgstr "Nom complet"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:6
-msgid "Joe Bloggs"
-msgstr "Joe Bloggs"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:7
-msgid "joe@example.com"
-msgstr "joe@exemple.com"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:9
-msgid "Confirm"
-msgstr "Confirmer"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:20
-msgid "Create Account"
-msgstr "Créer Compte"
-
-#~ msgid "SUBSCRIBE TO NEWSLETTER"
-#~ msgstr "INSCRIVEZ-VOUS A LA LETTRE DE DIFFUSION"
+#: ckanext/mailchimp/templates/user/edit_user_form.html:13
+msgid "An email has been sent to you to confirm your subscription."
+msgstr ""
 

--- a/ckanext/mailchimp/i18n/nl/LC_MESSAGES/ckanext-mailchimp.po
+++ b/ckanext/mailchimp/i18n/nl/LC_MESSAGES/ckanext-mailchimp.po
@@ -8,16 +8,44 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-mailchimp 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-10-18 15:21+0200\n"
+"POT-Creation-Date: 2025-10-16 08:39+0000\n"
 "PO-Revision-Date: 2019-09-20 14:10+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: nl\n"
 "Language-Team: nl <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.15.0\n"
+
+#: ckanext/mailchimp/controller.py:10
+msgid ""
+"A confirmation email was sent to you to verify your email address. Please"
+" check your spam folder if you did not receive this email. If the problem"
+" persists, contact us at <a "
+"href='mailto:contact@transportdata.be'>contact@transportdata.be</a>"
+msgstr "Een bevestigingsmail werd verstuurd naar uw email adres. Controleer uw spam folder indien u deze niet ontvangen heeft. Bij verdere problemen kan u ons contacteren via <a href='mailto:contact@transportdata.be'>contact@transportdata.be</a>"
+
+#: ckanext/mailchimp/controller.py:11
+msgid "An error occurred while adding you to the mailing list."
+msgstr "Er is een fout opgetreden bij het toevoegen aan de mailinglijst."
+
+#: ckanext/mailchimp/controller.py:12
+msgid "You already subscribed to the newsletter."
+msgstr "U bent reeds ingeschreven op de mailinglijst."
+
+#: ckanext/mailchimp/controller.py:13
+msgid "An error occurred while updating your information."
+msgstr "Er is een fout opgetreden tijdens het updaten van uw informatie"
+
+#: ckanext/mailchimp/controller.py:14
+msgid "Please provide a valid email address!"
+msgstr "Gelieve een geldig email adres op te geven!"
+
+#: ckanext/mailchimp/controller.py:21
+msgid "An error occurred"
+msgstr ""
 
 #: ckanext/mailchimp/templates/home/snippets/contact.html:3
 msgid "Subscribe to the mailing list"
@@ -36,9 +64,9 @@ msgstr "Schrijf in"
 msgid "SUBSCRIBE"
 msgstr "SCHRIJF IN"
 
+# | msgid "Subscribe to newsletter"
 #: ckanext/mailchimp/templates/home/snippets/newsletter.html:6
 #, fuzzy
-#| msgid "Subscribe to newsletter"
 msgid "TO NEWSLETTER"
 msgstr "Schrijf in op de nieuwsbrief "
 
@@ -46,120 +74,12 @@ msgstr "Schrijf in op de nieuwsbrief "
 msgid "Enter your email address"
 msgstr "Geef je e-mailadres in "
 
-#: ckanext/mailchimp/templates/user/edit_user_form.html:7
-msgid "Change details"
-msgstr "Contactgegevens veranderen"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:8
-#: ckanext/mailchimp/templates/user/new_user_form.html:5
-msgid "Username"
-msgstr "Gebruikersnaam"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:10
-msgid "Full name"
-msgstr "Volle naam"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:10
-msgid "eg. Joe Bloggs"
-msgstr "bv. Joe Bloggs"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:12
-#: ckanext/mailchimp/templates/user/new_user_form.html:7
-msgid "Email"
-msgstr "e-mail"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:12
-msgid "eg. joe@example.com"
-msgstr "bv. joe@voorbeeld.com"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:14
-msgid "About"
-msgstr "Over"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:14
-msgid "A little information about yourself"
-msgstr "Een beetje informatie over jezelf"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:17
-msgid "Subscribe to notification emails"
-msgstr "Schrijf in op e-mail alerten"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:18
-msgid ""
-"You will receive notification emails from {site_title}, e.g. when you "
-"have new activities on your dashboard."
-msgstr "Je zal email alerten van {site_title} ontvangen, bv. als je nieuwe activiteiten op je dashboard hebt. "
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:22
-#: ckanext/mailchimp/templates/user/new_user_form.html:10
+#: ckanext/mailchimp/templates/user/edit_user_form.html:9
+#: ckanext/mailchimp/templates/user/new_user_form.html:6
 msgid "Subscribe to newsletter"
 msgstr "Schrijf in op de nieuwsbrief "
 
-#: ckanext/mailchimp/templates/user/edit_user_form.html:28
-msgid "Change password"
-msgstr "Paswoord wijzigen"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:31
-msgid "Sysadmin Password"
-msgstr "Paswoord van systeemadministrator"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:31
-msgid "Old Password"
-msgstr "Oud paswoord"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:39
-#: ckanext/mailchimp/templates/user/new_user_form.html:8
-msgid "Password"
-msgstr "Paswoord"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:41
-msgid "Confirm Password"
-msgstr "Paswoord bevestigen"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:47
-msgid "Are you sure you want to delete this User?"
-msgstr "Ben je zeker dat je deze Gebruiker wil verwijderen?"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:47
-msgid "Delete"
-msgstr "Verwijderen"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:52
-msgid "Are you sure you want to regenerate the API key?"
-msgstr "Ben je zeker dat je de API sleutel wil regenereren?"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:52
-msgid "Regenerate API Key"
-msgstr "API sleutel regenereren"
-
-#: ckanext/mailchimp/templates/user/edit_user_form.html:56
-msgid "Update Profile"
-msgstr "Profiel bijwerken"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:5
-msgid "username"
-msgstr "Gebruikersnaam"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:6
-msgid "Full Name"
-msgstr "Volle naam"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:6
-msgid "Joe Bloggs"
-msgstr "Joe Bloggs"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:7
-msgid "joe@example.com"
-msgstr "joe@voorbeeld.com"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:9
-msgid "Confirm"
-msgstr "Bevestigen"
-
-#: ckanext/mailchimp/templates/user/new_user_form.html:20
-msgid "Create Account"
-msgstr "Account creëren"
-
-#~ msgid "SUBSCRIBE TO NEWSLETTER"
-#~ msgstr "SCHRIJF IN OP DE NIEUWSBRIEF"
+#: ckanext/mailchimp/templates/user/edit_user_form.html:13
+msgid "An email has been sent to you to confirm your subscription."
+msgstr ""
 

--- a/ckanext/mailchimp/logic/action/create.py
+++ b/ckanext/mailchimp/logic/action/create.py
@@ -1,7 +1,6 @@
 from ckan.logic.action.create import user_create
-from ckan.common import config
 
-from ckanext.mailchimp.logic.mailchimp import MailChimpClient
+from ckanext.mailchimp.logic.mailchimp import mailchimp_client as get_mailchimp_client
 from ckanext.mailchimp.util import name_splitter
 
 
@@ -24,12 +23,7 @@ def mailchimp_add_subscriber(firstname, lastname, email, tags=None):
     :param tags: array of tags for the subscriber -> https://mailchimp.com/help/manage-tags/
     :return: True if successful, False if not
     """
-    mailchimp_client = MailChimpClient(
-        api_key=config.get('ckan.mailchimp.api_key'),
-        base_url=config.get('ckan.mailchimp.base_url'),
-        member_list_id=config.get('ckan.mailchimp.member_list_id')
-    )
-
+    mailchimp_client = get_mailchimp_client()
     subscriber = mailchimp_client.find_subscriber_by_email(email)
     if not subscriber:
         success, message = mailchimp_client.create_new_subscriber(

--- a/ckanext/mailchimp/logic/action/create.py
+++ b/ckanext/mailchimp/logic/action/create.py
@@ -8,32 +8,30 @@ def mailchimp_user_create(context, data_dict):
     user = user_create(context, data_dict)
 
     if user and (data_dict or {}).get('newsletter') == 'subscribed':
-        first, last = name_splitter(data_dict.get('fullname', data_dict.get('name')))
-        mailchimp_add_subscriber(first, last, data_dict.get('email'), tags=["NAP-user"])
+        name = data_dict.get('fullname', data_dict.get('name'))
+        mailchimp_add_subscriber(name, data_dict.get('email'), tags=["NAP-user"])
     return user
 
 
-def mailchimp_add_subscriber(firstname, lastname, email, tags=None):
+def mailchimp_add_subscriber(name, email, tags=None):
     """
     if user is not already in mailchimp add user to mailchimp
 
-    :param firstname: first name of the subscriber
-    :param lastname: last name of the subscriber
+    :param name: full name of the subscriber
     :param email: email of the subscriber
     :param tags: array of tags for the subscriber -> https://mailchimp.com/help/manage-tags/
     :return: True if successful, False if not
     """
     mailchimp_client = get_mailchimp_client()
-    subscriber = mailchimp_client.find_subscriber_by_email(email)
-    if not subscriber:
+    if not mailchimp_client.is_active_subscriber(email):
         success, message = mailchimp_client.create_new_subscriber(
-            firstname,
-            lastname,
+            name,
             email,
             tags
         )
         return success, message
     else:
+        subscriber = mailchimp_client.find_subscriber_by_email(email)
         subscriber_tags = [tag.get('name', '') for tag in subscriber.get('tags', [])]
         merged_tags = subscriber_tags + tags if tags else subscriber_tags
         success = mailchimp_client.update_subscriber_tags(subscriber.get('id'), merged_tags)

--- a/ckanext/mailchimp/logic/action/update.py
+++ b/ckanext/mailchimp/logic/action/update.py
@@ -1,9 +1,8 @@
 from ckan.common import config
 from ckan.logic.action.update import user_update
+import ckan.plugins.toolkit as tk
 
-from ckanext.mailchimp.logic.mailchimp import MailChimpClient
-from ckanext.mailchimp.util import name_splitter
-
+from ckanext.mailchimp.logic.mailchimp import mailchimp_client
 
 def mailchimp_user_update(context, data_dict):
     '''
@@ -12,31 +11,32 @@ def mailchimp_user_update(context, data_dict):
     This is why we added the 'is-edit-user' to make sure to only update the newsletter preferences there.
     Otherwise we might remove a user from the mailing list by accident because the newsletter attribute is only 
     added to the data_dict when submitting via that form.
-
-    TODO: To fix this issue, we should store the newsletter subscribed state in the
-    database, so we need to add this property to the user model.
     '''
+    previous_user_data = tk.get_action('user_show')(context, {'id': data_dict['id']})
+    previous_email = previous_user_data.get('email')
+    previous_name = previous_user_data.get('fullname', previous_user_data.get('name'))
     user = user_update(context, data_dict)
     # Make sure to only update mailchimp settings when changes are made
     # Via the form
     if not data_dict.get('should-update-newsletter'):
         return user
 
-    client = MailChimpClient(
-        api_key=config.get('ckan.mailchimp.api_key'),
-        base_url=config.get('ckan.mailchimp.base_url'),
-        member_list_id=config.get('ckan.mailchimp.member_list_id')
-    )
+    client = mailchimp_client()
+    
     if data_dict:
         user_email = data_dict.get('email')
+        name = data_dict.get('fullname', data_dict.get('name'))
+        if previous_email != user_email:
+            # User changed email. Remove old email from the subscription list
+            client.delete_subscriber_by_email(previous_email)
+        elif previous_name != name:
+            client.update_subscriber_name(user_email, name)
+
         if data_dict.get('newsletter') == 'subscribed':
-            # if user is not already in mailchimp add user to mailchimp
-            if user_email and not client.find_subscriber_by_email(user_email):
-                first, last = name_splitter(
-                    data_dict.get('fullname', data_dict.get('name'))
-                )
+            # if user is not already a subscriber, add them
+            if user_email and not client.is_active_subscriber(user_email):
                 client.create_new_subscriber(
-                    first, last, user_email, tags=["NAP-user"]
+                    name, user_email, tags=["NAP-user"]
                 )
         else:
             client.delete_subscriber_by_email(user_email)

--- a/ckanext/mailchimp/logic/mailchimp/__init__.py
+++ b/ckanext/mailchimp/logic/mailchimp/__init__.py
@@ -1,10 +1,26 @@
 import json
 import logging
 import requests
+from ckan.common import config
+from ckanext.mailchimp.util import name_splitter
 
+def mailchimp_client():
+  client = MailChimpClient(
+        api_key=config.get('ckan.mailchimp.api_key'),
+        base_url=config.get('ckan.mailchimp.base_url'),
+        member_list_id=config.get('ckan.mailchimp.member_list_id')
+    )
+  return client
 
 class MailChimpClient(object):
-
+    # lifecycle status is:
+    # start: create with pending
+    # => subscribed if accepted
+    # => archived if unsubscribe
+    # => back to pending if resubscribe
+    STATUS_SUBSCRIBED = "subscribed"
+    STATUS_PENDING = "pending"
+    STATUS_ARCHIVED = "archived"
     def __init__(self, api_key, base_url, member_list_id):
         assert api_key, "An API key must be supplied"
         assert base_url, "A base URL must be supplied"
@@ -15,34 +31,67 @@ class MailChimpClient(object):
         self.headers = {"Authorization": "apikey {0}".format(api_key)}
         self.logger = logging.getLogger(__name__)
 
+    def is_active_subscriber(self, email):
+        subscriber = self.find_subscriber_by_email(email)
+        return subscriber and subscriber.get("status") == self.STATUS_SUBSCRIBED
+      
+    def is_pending_subscriber(self, email):
+        subscriber = self.find_subscriber_by_email(email)
+        return subscriber and subscriber.get("status") == self.STATUS_PENDING
+
+    def is_archived_subscriber(self, email):
+        subscriber = self.find_subscriber_by_email(email)
+        return subscriber and subscriber.get("status") == self.STATUS_ARCHIVED
+
     def find_subscriber_by_email(self, email):
         response = requests.get(f"{self.base_url}/search-members?query={email}", headers=self.headers)
         response_obj = response.json()
-        if response.status_code == 200 and len(response_obj["exact_matches"]["members"]) >= 1:
+        if response.status_code == 200:
+          if len(response_obj["exact_matches"]["members"]) >= 1:
             return response_obj["exact_matches"]["members"][0]
+          elif len(response_obj["full_search"]["members"]) >= 1:
+            # This endpoint does not count email addresses with a '+' as a, exact match,
+            # but will still show them in full_search. So check for exact matches in full_search too.
+            # This might be mailchimp stripping away the '+' part, or something else.
+            for member in response_obj["full_search"]["members"]:
+                if member.get("email_address") == email:
+                    return member
 
-    def create_new_subscriber(self, firstname, lastname, email, tags=None):
-        create_data = {
-            "email_address": email,
-            "status": "pending",
-            "merge_fields": {
-                "FNAME": firstname,
-                "LNAME": lastname
-            }
-        }
-        if tags and len(tags) > 0:
-            create_data["tags"] = []
-            for tag in tags:
-                create_data["tags"].append(tag)
-        response = requests.post(f"{self.base_url}/lists/{self.member_list_id}/members",
-                                 json.dumps(create_data), headers=self.headers)
+        return None
+
+    def create_new_subscriber(self, name, email, tags=None):
+        subscriber = self.find_subscriber_by_email(email)
+        if subscriber and subscriber.get("status") == self.STATUS_ARCHIVED:
+            # user was subscribed in the past and unsubbed, making them archived. 
+            # Resubscribe via status change. This is set to "pending" instead of "subscribed" so
+            # the user has to reconfirm their subscription. This avoids users using someone else's email address
+            # to subscribe them without their consent.
+            response = requests.patch(f"{self.base_url}/lists/{self.member_list_id}/members/{subscriber['contact_id']}",
+                                 json.dumps({"status": self.STATUS_PENDING}), headers=self.headers)
+        else:
+          firstname, lastname = name_splitter(name)
+          create_data = {
+              "email_address": email,
+              "status": self.STATUS_PENDING,
+              "merge_fields": {
+                  "FNAME": firstname,
+                  "LNAME": lastname
+              }
+          }
+          if tags and len(tags) > 0:
+              create_data["tags"] = []
+              for tag in tags:
+                  create_data["tags"].append(tag)
+          response = requests.post(f"{self.base_url}/lists/{self.member_list_id}/members",
+                                  json.dumps(create_data), headers=self.headers)
+
         if response.status_code in [200, 201]:
             succes = True
             message = "SUCCESS"
         elif response.status_code in [400] and response.json().get("title", "") == "Member Exists":
             succes = False
             message = "ALREADY_SUBSCRIBED"
-            self.logger.warn(response.json().get("detail", "Already a list member"))
+            self.logger.warning(response.json().get("detail", "Already a list member"))
         else:
             succes = False
             message = "ERROR_ADD"
@@ -57,6 +106,19 @@ class MailChimpClient(object):
                 headers=self.headers
             )
 
+    def update_subscriber_name(self, email, name):
+        subscriber = self.find_subscriber_by_email(email)
+        if subscriber:
+            firstname, lastname = name_splitter(name)
+            response = requests.patch(
+                f"{self.base_url}/lists/{self.member_list_id}/members/{subscriber['contact_id']}",
+                json.dumps({"merge_fields": {"FNAME": firstname, "LNAME": lastname}}),
+                headers=self.headers
+            )
+            if response.status_code not in [200, 201, 204]:
+                self.logger.error(response.text)
+                return False
+            return True
     def update_subscriber_tags(self, subscriber_id, tags):
         tag_objects = [{"name": tag, "status": "active"} for tag in tags]
         response = requests.post(

--- a/ckanext/mailchimp/logic/mailchimp/__init__.py
+++ b/ckanext/mailchimp/logic/mailchimp/__init__.py
@@ -30,6 +30,7 @@ class MailChimpClient(object):
         self.member_list_id = member_list_id
         self.headers = {"Authorization": "apikey {0}".format(api_key)}
         self.logger = logging.getLogger(__name__)
+        self.sub_by_email_cache = {}
 
     def is_active_subscriber(self, email):
         subscriber = self.find_subscriber_by_email(email)
@@ -44,6 +45,13 @@ class MailChimpClient(object):
         return subscriber and subscriber.get("status") == self.STATUS_ARCHIVED
 
     def find_subscriber_by_email(self, email):
+        if email in self.sub_by_email_cache:
+            return self.sub_by_email_cache[email]
+        subscriber = self._get_subscriber_by_email(email)
+        self.sub_by_email_cache[email] = subscriber
+        return subscriber
+
+    def _get_subscriber_by_email(self, email):
         response = requests.get(f"{self.base_url}/search-members?query={email}", headers=self.headers)
         response_obj = response.json()
         if response.status_code == 200:

--- a/ckanext/mailchimp/plugin.py
+++ b/ckanext/mailchimp/plugin.py
@@ -18,10 +18,11 @@ def get_blueprint():
     return bp
 
 
-# TODO: Add IConfigDeclaration implementation for the 3 config options
+@plugins.toolkit.blanket.helpers
 class MailchimpPlugin(plugins.SingletonPlugin,  DefaultTranslation):
     plugins.implements(plugins.ITranslation)
     plugins.implements(plugins.IConfigurer, inherit=True)
+    plugins.implements(plugins.IConfigDeclaration, inherit=True)
     plugins.implements(plugins.IActions, inherit=True)
     plugins.implements(plugins.IBlueprint)
 
@@ -41,3 +42,18 @@ class MailchimpPlugin(plugins.SingletonPlugin,  DefaultTranslation):
     # IBlueprint
     def get_blueprint(self):
         return get_blueprint()
+
+    # IConfigDeclaration
+    def declare_config_options(self, declaration, key):
+        declaration.annotate("Mailchimp integration")
+        group = key.ckan.mailchimp
+
+        declaration.declare(group.api_key, "").set_description(
+            "Mailchimp API key"
+        )
+        declaration.declare(group.base_url, "").set_description(
+            "Mailchimp API base URL (eg: https://<dc>.api.mailchimp.com/3.0)"
+        )
+        declaration.declare(group.member_list_id, "").set_description(
+            "Mailchimp audience/list ID"
+        )

--- a/ckanext/mailchimp/templates/user/edit_user_form.html
+++ b/ckanext/mailchimp/templates/user/edit_user_form.html
@@ -3,5 +3,14 @@
 {% block extra_fields %}
   {{ super() }}
   {{ form.hidden("should-update-newsletter", value="true") }} {# Super hacky, we need to know when update_user is called from this form so we can update mail preferences. #}
-  {{ form.checkbox("newsletter", id="field-newsletter", label=_("Subscribe to newsletter"), checked=true, value='subscribed', classes=["control-medium"]) }}
+  {% set is_subscribed = h.mailchimp_is_user_subscribed(data['email']) %}
+  {% set is_pending = h.mailchimp_is_user_pending(data['email']) %}
+  {% call form.checkbox("newsletter", id="field-newsletter",
+     label=_("Subscribe to newsletter"),
+     checked=is_subscribed or is_pending,
+     value='subscribed', classes=["control-medium"]) %}
+    {% if is_pending %}
+      {{ form.info(_("An email has been sent to you to confirm your subscription.")) }}
+    {% endif %}
+  {% endcall %}
 {% endblock %}

--- a/compile_translations.sh
+++ b/compile_translations.sh
@@ -1,0 +1,9 @@
+CKAN_BASE=ckan/ckan-base:2.11
+docker run --rm --entrypoint bash -u root -v .:/external "$CKAN_BASE" -lc '
+    cd /external
+    
+    if ! python setup.py compile_catalog;  then 
+        echo "!! Error while compiling translations, compilation cancelled. !!"
+        exit 1
+    fi
+  '

--- a/extract_translatable_strings.sh
+++ b/extract_translatable_strings.sh
@@ -1,0 +1,13 @@
+CKAN_BASE=ckan/ckan-base:2.11
+docker run --rm --entrypoint bash -u root -v .:/external "$CKAN_BASE" -lc '
+    cd /external
+    if ! python setup.py extract_messages; then
+        echo "!! Error while extracting strings, extraction cancelled. !!"
+        exit 1
+    fi
+    if ! python setup.py update_catalog --no-fuzzy-matching ; then
+        echo "!! Error while updating translations, update cancelled. !!"
+        exit 1
+    fi
+    echo "!! make sure to run compile_translations.sh to update the .mo files after adjusting the missing translations. !!"
+  '


### PR DESCRIPTION
- add helpers to check if user is subscribed/pending
  - use this information to correctly check the checkbox for "subscribed" based on the status. If the user is pending, show a message.
- create a get_mailchimp_client "factory" to avoid duplicate code
- if a user changes email, make sure to "unsubscribe" the old email. If user pressed subscribe, also subscribe the new email.
- fix resubscribing: before it was not possible to subscribe again after unsubscribing. This is now fixed. Resubscribing means going back to "pending" (not instantly to "subscribed"), so a confirmation email is send. This avoids potential misuse.
- if a user changes their name, change this in mailchimp too.
- cleanup lifecycle status code (use constants, add helper functions)
- Handle email address with a "+" in. Before this wouldn't allow a user to unsubscribe via the website.
- add IConfigDeclaration: no more warnings because of usage of mailchimp env variables.
- add translations scripts to extract translations
  - also fix translation related issues. 
  - Remove ckan-core overwrite translations (and move them to benap plugin, see https://github.com/belgium-its-steering-committee/ckanext-benap/pull/122 )
  - Translate flash_messages via .po files instead of hardcoded code.
- some small caching for get_subscriber. This is not yet utilized fully (as most code just creates a new mailchimp client).
  